### PR TITLE
Noop-ing JMX Collector

### DIFF
--- a/tools/stress/src/org/apache/cassandra/stress/util/JmxCollector.java
+++ b/tools/stress/src/org/apache/cassandra/stress/util/JmxCollector.java
@@ -82,8 +82,8 @@ public class JmxCollector implements Callable<JmxCollector.GcStats>
         int i = 0;
         for (String host : hosts)
         {
-            probes[i] = connect(host, port);
-            probes[i].getAndResetGCStats();
+            //probes[i] = connect(host, port);
+            //probes[i].getAndResetGCStats();
             i++;
         }
     }


### PR DESCRIPTION
I'd like to disable JMX collector so that the connections to the endpoint are established much faster.